### PR TITLE
Hard reset

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -5,5 +5,6 @@
 	<classpathentry kind="src" path="src/main/resources"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
 	<classpathentry kind="con" path="org.maven.ide.eclipse.MAVEN2_CLASSPATH_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/3"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/src/main/java/framboos/GpioPin.java
+++ b/src/main/java/framboos/GpioPin.java
@@ -12,6 +12,10 @@ public class GpioPin {
 	// REV 2:
 	private static final int [] mappedPins = {17, 18, 27, 22, 23, 24, 25, 4, 2, 3, 8, 7, 10, 9, 11, 14, 15};
 	
+	public static int[] getMappedPins() {
+		return mappedPins;
+	}
+	
 	protected final int pinNumber;
 	
 	protected boolean isClosing = false;

--- a/src/main/java/framboos/util/HardReset.java
+++ b/src/main/java/framboos/util/HardReset.java
@@ -1,0 +1,26 @@
+package framboos.util;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import framboos.FilePaths;
+import framboos.GpioPin;
+
+public class HardReset {
+	static final int [] mappedPins = GpioPin.getMappedPins();
+	
+	public static boolean hardResetPin(int pinNumber) {
+		if ((pinNumber < 0) || (pinNumber > 16))
+			return false;
+		try {
+			pinNumber = mappedPins[pinNumber];
+			String valueString = Integer.toString(pinNumber);
+			FileOutputStream fos = new FileOutputStream(FilePaths.getUnexportPath());
+			fos.write(valueString.getBytes());
+			fos.close();
+		} catch (IOException e) {			
+			return false;				
+		}
+		return true;
+	}
+}


### PR DESCRIPTION
Added functionality to force reset of a Pin.

When opening a Pin with framboos from an application that is killed before it was able to close the Pin, reopening it will cause an exception.

The static method HardReset.hardResetPin(pinNumber) will return true upon success or false if the pin was not open or does not exist.
