### PR TITLE
Update to allow direct addressing of pins, and GPIO string decoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ target/
 .setings/
 .project
 .classpath
-
+*.class

--- a/README
+++ b/README
@@ -1,3 +1,5 @@
+UPDATED TO USE BEAGLEBOARD AND ALL LINUX GPIO BASED FS
+
 Framboos is a small Java wrapper around the GPIO driver under /sys/class/gpio. 
 It supports in and out pins. PWM pins will be covered when the underlying driver does.
 
@@ -18,6 +20,9 @@ It is important to close pins that are created, so that they are released for
 other programs.
 
 == Pin assignment ==
+
+When passing an INT to a constructor it will default to the wiringPi layout, when passing a STRING representation (i.e. GPIO2_1 for BeagleBone) it will direct address the pinout, bypassing wiringPi
+
 
 GPIO pins in the numbering used by wiringPi: 
 

--- a/src/main/java/framboos/GpioPin.java
+++ b/src/main/java/framboos/GpioPin.java
@@ -12,8 +12,9 @@ public class GpioPin {
 	// private static final int [] mappedPins = {17, 18, 21, 22, 23, 24, 25, 4, 0, 1, 8, 7, 10, 9, 11, 14, 15};
 	// REV 2:
 	private static final int [] mappedPins = {17, 18, 27, 22, 23, 24, 25, 4, 2, 3, 8, 7, 10, 9, 11, 14, 15};
-	public static Pattern pinPattern = Pattern.compile("(gpio)([0-9])_([0-9]*)");
-	public static Pattern pinPatternAlt = Pattern.compile("([0-9]*)");
+	public static Pattern pinPattern = Pattern.compile("(gpio)([0-9])_([0-9]*)", Pattern.CASE_INSENSITIVE);
+	public static Pattern pinPatternAlt = Pattern.compile("(gpio)([0-9]*)",Pattern.CASE_INSENSITIVE);
+	public static Pattern pinPatternNumber = Pattern.compile("([0-9]*)");
 
 	
 	public static int[] getMappedPins() {
@@ -106,11 +107,16 @@ public class GpioPin {
                 } else {
                         matcher = pinPatternAlt.matcher(pinName);
                         if(matcher.find()) {
+                                pinNumber = Integer.parseInt(matcher.group(2));
+								} else {
+	                        matcher = pinPatternNumber.matcher(pinName);
+	                        if(matcher.find()) {
                                 pinNumber = Integer.parseInt(matcher.group(1));
-                        } else {
-                                System.out.println("Could not match " + pinName + ". As a valid gpio pinout number");
-                                System.exit(1);
-                        }
+   	                     } else {
+                               System.out.println("Could not match " + pinName + ". As a valid gpio pinout number");
+                           	 System.exit(1);
+                        	}
+								}
 
                 }
                 return pinNumber;

--- a/src/main/java/framboos/GpioPin.java
+++ b/src/main/java/framboos/GpioPin.java
@@ -5,12 +5,16 @@ import static framboos.FilePaths.*;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.regex.*;
 
 public class GpioPin {
 	// REV 1:
 	// private static final int [] mappedPins = {17, 18, 21, 22, 23, 24, 25, 4, 0, 1, 8, 7, 10, 9, 11, 14, 15};
 	// REV 2:
 	private static final int [] mappedPins = {17, 18, 27, 22, 23, 24, 25, 4, 2, 3, 8, 7, 10, 9, 11, 14, 15};
+	public static Pattern pinPattern = Pattern.compile("(gpio)([0-9])_([0-9]*)");
+	public static Pattern pinPatternAlt = Pattern.compile("([0-9]*)");
+
 	
 	public static int[] getMappedPins() {
 		return mappedPins;
@@ -22,6 +26,18 @@ public class GpioPin {
 	
 	public GpioPin(int pinNumber, Direction direction) {
 		this.pinNumber = mappedPins[pinNumber];
+		writeFile(getExportPath(), Integer.toString(this.pinNumber));
+		writeFile(getDirectionPath(this.pinNumber), direction.getValue());
+	}
+
+	public GpioPin(int pinNumber, Direction direction, boolean direct) {
+		/* Allow Override of the mapping for people to directly drive the GPIOs in the numbering they want */
+		if(!direct) {
+			this.pinNumber = mappedPins[pinNumber];
+		} else {
+			this.pinNumber = pinNumber;
+		}
+		
 		writeFile(getExportPath(), Integer.toString(this.pinNumber));
 		writeFile(getDirectionPath(this.pinNumber), direction.getValue());
 	}
@@ -70,4 +86,25 @@ public class GpioPin {
 			return value;
 		}
 	}
+
+        public static int getPinNumber(String pinName) {
+
+                int pinNumber = -1;
+                Matcher matcher = pinPattern.matcher(pinName);
+                if(matcher.find()) {
+                        pinNumber = Integer.parseInt(matcher.group(2))*32 + Integer.parseInt(matcher.group(3));
+                } else {
+                        matcher = pinPatternAlt.matcher(pinName);
+                        if(matcher.find()) {
+                                pinNumber = Integer.parseInt(matcher.group(1));
+                        } else {
+                                System.out.println("Could not match " + pinName + ". As a valid gpio pinout number");
+                                System.exit(1);
+                        }
+
+                }
+                return pinNumber;
+
+        }
+
 }

--- a/src/main/java/framboos/GpioPin.java
+++ b/src/main/java/framboos/GpioPin.java
@@ -52,6 +52,9 @@ public class GpioPin {
 			fis.close();
 			return value;
 		} catch (IOException e) {
+			if(e.getMessage().contains("Permission Denied")) {
+				throw new RuntimeException("Permission denied to GPIO file: " + e.getMessage());
+			}
 			throw new RuntimeException("Could not read from GPIO file: " + e.getMessage());
 		}
 	}
@@ -63,10 +66,17 @@ public class GpioPin {
 	
 	protected void writeFile(String fileName, String value) {
 		try {
+			// check for permission
 			FileOutputStream fos = new FileOutputStream(fileName);
 			fos.write(value.getBytes());
 			fos.close();
 		} catch (IOException e) {
+			if(e.getMessage().contains("Permission denied")) {
+				throw new RuntimeException("Permission denied to GPIO file: " + e.getMessage());
+			} else if (e.getMessage().contains("busy")) {
+				System.out.println("GPIO is already exported, continuing");
+				return;
+			}
 			throw new RuntimeException("Could not write to GPIO file: " + e.getMessage());
 		}
 	}

--- a/src/main/java/framboos/InPin.java
+++ b/src/main/java/framboos/InPin.java
@@ -1,8 +1,13 @@
 package framboos;
 
 public class InPin extends GpioPin {
-
+		
 	public InPin(int pinNumber) {
 		super(pinNumber, Direction.IN);
 	}
+
+	public InPin(String pinName) {
+		super(getPinNumber(pinName), Direction.IN, true);
+	}
+
 }

--- a/src/main/java/framboos/OutPin.java
+++ b/src/main/java/framboos/OutPin.java
@@ -8,6 +8,11 @@ public class OutPin extends GpioPin {
 		super(pinNumber, Direction.OUT);
 		setValue(false);
 	}
+
+	public OutPin(String pinName) {
+		super(getPinNumber(pinName), Direction.OUT, true);
+		setValue(false);
+	}
 	
 	public void setValue(boolean isOne) {
 		if (!isClosing) {

--- a/src/main/java/framboos/PwmPin.java
+++ b/src/main/java/framboos/PwmPin.java
@@ -9,6 +9,11 @@ public class PwmPin extends GpioPin {
 		setValue(0);
 	}
 	
+	public PwmPin(String pinName) {
+		super(getPinNumber(pinName), Direction.PWM, true);
+		setValue(0);
+	}
+	
 	/**
 	 * Set the value in integer, from 0.0 (all off) to 1023 (all on)
 	 * @param value

--- a/src/main/java/framboos/ReverseInPin.java
+++ b/src/main/java/framboos/ReverseInPin.java
@@ -6,6 +6,10 @@ public class ReverseInPin extends InPin {
 		super(pinNumber);
 	}
 
+	public ReverseInPin(String pinName) {
+		super(pinName);
+	}
+
 	@Override
 	public boolean getValue() {
 		return !super.getValue();


### PR DESCRIPTION
Constructors now take strings to allow direct addressing. I.e. InPin("1")

Using the Beagleboards naming scheme will decode to the correct GPIO Pin. So Inpin("GPIO1_23") will decode to GPIO("45");
